### PR TITLE
Desactivate login option

### DIFF
--- a/app/controllers/shib/Shibboleth.java
+++ b/app/controllers/shib/Shibboleth.java
@@ -44,12 +44,15 @@ public class Shibboleth extends Controller {
 	 */
 	@Before(unless = { "login", "authenticate", "logout" })
 	static void checkAccess() throws Throwable {
-
-		// Redirect to login
-		if (!session.contains("shibboleth")) {
-			flash.put("url", "GET".equals(request.method) ? request.url : null);
-			Logger.debug("Shib: User requires authentication to access: "+request.url);
-			login();
+		String shibLoginActivated = Play.configuration.getProperty("shib.login",
+				"true");
+		if(Boolean.parseBoolean(shibLoginActivated)){
+			// Redirect to login
+			if (!session.contains("shibboleth")) {
+				flash.put("url", "GET".equals(request.method) ? request.url : null);
+				Logger.debug("Shib: User requires authentication to access: "+request.url);
+				login();
+			}
 		}
 
 		// Check authentication profiles


### PR DESCRIPTION
Here is another pull request :o). It's not urgent!

With this modification you can add a "shib.login=false" to the application.conf. 
When the value is set to false the module doesn't redirect the user to the login url set with the "shib.login.url" property. This capability to desactivate login is necessary when you prefer to set the shibboleth login redirection at the level of the web server and don't want to let the application handle the redirection (it's a bit more secure).

By default the "shib.login" is set to true (so it can be omitted in the application.conf).

If you think this modification can be useful I can also pull a request to add a test and eventually a documentation modification.

And again, thank you for this great plugin!
